### PR TITLE
Update location of ansible.cfg

### DIFF
--- a/config/dockerfiles/ansible/Dockerfile
+++ b/config/dockerfiles/ansible/Dockerfile
@@ -8,7 +8,7 @@ LABEL name="contrainfra/ansible-executor" \
 ENV APP_ROOT=/ansible/
 ENV PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
 
-COPY ansible.cfg /etc/ansible.cfg
+COPY ansible.cfg /etc/ansible/ansible.cfg
 COPY bin/ ${APP_ROOT}/bin/
 
 RUN dnf install -y ansible \

--- a/config/dockerfiles/ansible/ansible.cfg
+++ b/config/dockerfiles/ansible/ansible.cfg
@@ -2,3 +2,4 @@
 inventory = /ansible/inventory
 host_key_checking = False
 host_key_auto_add = True
+deprecation_warnings = False

--- a/config/dockerfiles/linchpin/Dockerfile
+++ b/config/dockerfiles/linchpin/Dockerfile
@@ -9,7 +9,7 @@ ENV APP_ROOT=/linchpin/
 ENV PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
 
 
-COPY ansible.cfg /etc/ansible.cfg
+COPY ansible.cfg /etc/ansible/ansible.cfg
 COPY bin/ ${APP_ROOT}/bin/
 
 RUN dnf install -y git \


### PR DESCRIPTION
Previously, the Dockerfiles specified that the ansible.cfg file should be
copied to /etc/ansible.cfg, however according to [1] the actual location
should be /etc/ansible/ansible.cfg

https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/intro_configuration.html