### PR TITLE
Fix typo in sample container buildconfig template

### DIFF
--- a/config/s2i/samples/pipeline-sample-container/pipeline-sample-container-buildconfig-template.yml
+++ b/config/s2i/samples/pipeline-sample-container/pipeline-sample-container-buildconfig-template.yml
@@ -53,7 +53,7 @@ parameters:
 - description: The sub-directory inside the repository.
   displayName: Context Directory
   name: REPO_CONTEXTDIR
-  value: config/Dockerfiles/pipeline-sample-container
+  value: config/dockerfiles/pipeline-sample-container
 - description: The git ref or tag to use for customization.
   displayName: Git Reference
   name: REPO_REF


### PR DESCRIPTION
Fix typo in the folder name _dockerfiles_ in sample container buildconfig template