### PR TITLE
updating openshift sync plugin

### DIFF
--- a/config/s2i/jenkins/master/plugins.txt
+++ b/config/s2i/jenkins/master/plugins.txt
@@ -76,7 +76,7 @@ node-iterator-api:1.5
 openshift-client:1.0.9
 openshift-login:1.0.8
 openshift-pipeline:1.0.54
-openshift-sync:1.0.9
+openshift-sync:1.0.23
 parameterized-trigger:2.35.2
 pipeline-build-step:2.7
 pipeline-github-lib:1.0


### PR DESCRIPTION
1.0.23 of the openshift-sync plugin allows for openshift secrets to sync with the jenkins credentials plugin.

