### PR TITLE
Job dsl

### DIFF
--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -284,6 +284,6 @@ parameters:
 - name: DSL_JOB_REPO
   displayName: DSL job repo
   description: The repository of dsl jobs
-  value: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
+  value: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
 labels:
   template: jenkins-persistent

--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -243,7 +243,7 @@ parameters:
   value: https://github.com/joejstuart/contra-env-sample-project
 - description: Git branch/tag reference
   name: REPO_REF
-  value: jobDsl
+  value: testEnv
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR
   value: config/s2i/jenkins/master

--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -243,7 +243,7 @@ parameters:
   value: https://github.com/joejstuart/contra-env-sample-project
 - description: Git branch/tag reference
   name: REPO_REF
-  value: testEnv
+  value: jobDsl
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR
   value: config/s2i/jenkins/master
@@ -284,6 +284,6 @@ parameters:
 - name: DSL_JOB_REPO
   displayName: DSL job repo
   description: The repository of dsl jobs
-  value: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
+  value: 'https://github.com/joejstuart/contra-env-sample-project.git'
 labels:
   template: jenkins-persistent

--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -236,10 +236,10 @@ parameters:
 - description: Git source URI for Jenkins S2I
   name: REPO_URL
   required: true
-  value: https://github.com/CentOS-PaaS-SIG/contra-env-sample-project
+  value: https://github.com/joejstuart/contra-env-sample-project
 - description: Git branch/tag reference
   name: REPO_REF
-  value: master
+  value: jobDsl
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR
   value: config/s2i/jenkins/master
@@ -273,5 +273,13 @@ parameters:
   displayName: Jenkins ImageStreamTag
   description: Name of the ImageStreamTag to be used for the Jenkins image.
   value: jenkins:latest
+- name: LOAD_SEED_JOB
+  displayName: Load seed job
+  description: Whether to load a dsl seed job
+  value: 'true'
+- name: DSL_JOB_REPO
+  displayName: DSL job repo
+  description: The repository of dsl jobs
+  value: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
 labels:
   template: jenkins-persistent

--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -163,6 +163,10 @@ objects:
             value: 'true'
           - name: OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS
             value: 'true'
+          - name: LOAD_SEED_JOB
+            value: ${LOAD_SEED_JOB}
+          - name: DSL_JOB_REPO
+            value: ${DSL_JOB_REPO}
           resources:
             limits:
               memory: "${MEMORY_LIMIT}"

--- a/config/s2i/jenkins/jenkins-persistent-template.yml
+++ b/config/s2i/jenkins/jenkins-persistent-template.yml
@@ -240,10 +240,10 @@ parameters:
 - description: Git source URI for Jenkins S2I
   name: REPO_URL
   required: true
-  value: https://github.com/joejstuart/contra-env-sample-project
+  value: https://github.com/CentOS-PaaS-SIG/contra-env-sample-project
 - description: Git branch/tag reference
   name: REPO_REF
-  value: jobDsl
+  value: master
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR
   value: config/s2i/jenkins/master
@@ -284,6 +284,6 @@ parameters:
 - name: DSL_JOB_REPO
   displayName: DSL job repo
   description: The repository of dsl jobs
-  value: 'https://github.com/joejstuart/contra-env-sample-project.git'
+  value: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
 labels:
   template: jenkins-persistent

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -9,12 +9,12 @@ import jenkins.model.*
 import jenkins.plugins.git.GitSCMSource
 import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait
 import jenkins.security.s2m.*
-import jenkins.security.s2m.*
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
 import javaposse.jobdsl.dsl.DslScriptLoader
 import javaposse.jobdsl.plugin.JenkinsJobManagement
+import javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration
 
 
 import java.util.logging.Logger
@@ -100,6 +100,9 @@ sharedLibConfigs.each { libConfig ->
     lib.defaultVersion = "master"
     GlobalLibraries.get().getLibraries().add(lib)
 }
+
+logger.info('Disabling job dsl script security')
+GlobalConfiguration.all().get(GlobalJobDslSecurityConfiguration.class).useScriptSecurity=false
 
 env = System.getenv()
 if (env['LOAD_SEED_JOB']) {

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -101,11 +101,11 @@ sharedLibConfigs.each { libConfig ->
     GlobalLibraries.get().getLibraries().add(lib)
 }
 
-logger.info('Disabling job dsl script security')
-GlobalConfiguration.all().get(GlobalJobDslSecurityConfiguration.class).useScriptSecurity=false
 
 env = System.getenv()
 if (env['LOAD_SEED_JOB']) {
+    logger.info('Disabling job dsl script security')
+    GlobalConfiguration.all().get(GlobalJobDslSecurityConfiguration.class).useScriptSecurity=false
     def JENKINS_SEED_JOB = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"
     def config = new File(JENKINS_SEED_JOB).text
 

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -103,14 +103,13 @@ sharedLibConfigs.each { libConfig ->
 
 env = System.getenv()
 if (env['LOAD_SEED_JOB']) {
-    def JENKINS_SETUP_YAML = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"
+    def JENKINS_SEED_JOB = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"
     def config = new File(JENKINS_SEED_JOB).text
 
     def workspace = new File("${env['JENKINS_HOME']}")
-    def seedJobDsl = config.seed_jobdsl
 
     def jobManagement = new JenkinsJobManagement(System.out, [:], workspace)
-    new DslScriptLoader(jobManagement).runScript(seedJobDsl)
+    new DslScriptLoader(jobManagement).runScript(config)
     logger.info('Created seed job')
 }
 

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -101,6 +101,7 @@ sharedLibConfigs.each { libConfig ->
     GlobalLibraries.get().getLibraries().add(lib)
 }
 
+env = System.getenv()
 if (env['LOAD_SEED_JOB']) {
     def JENKINS_SETUP_YAML = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"
     def config = new File(JENKINS_SEED_JOB).text

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -103,7 +103,7 @@ sharedLibConfigs.each { libConfig ->
 
 
 env = System.getenv()
-if (env['LOAD_SEED_JOB']) {
+if (env['LOAD_SEED_JOB'] == 'true') {
     logger.info('Disabling job dsl script security')
     GlobalConfiguration.all().get(GlobalJobDslSecurityConfiguration.class).useScriptSecurity=false
     def JENKINS_SEED_JOB = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -68,6 +68,11 @@ def sharedLibConfigs = [
                 "contra-library",
                 "https://github.com/CentOS-PaaS-SIG/contra-env-sample-project",
                 ["+refs/heads/*:refs/remotes/origin/*  +refs/pull/*:refs/remotes/origin/pr/*"]
+        ),
+        new Tuple(
+                "contra-lib",
+                "https://github.com/openshift/contra-lib",
+                ["+refs/heads/*:refs/remotes/origin/*  +refs/pull/*:refs/remotes/origin/pr/*"]
         )
 ]
 
@@ -92,3 +97,16 @@ sharedLibConfigs.each { libConfig ->
     lib.defaultVersion = "master"
     GlobalLibraries.get().getLibraries().add(lib)
 }
+
+if (env['LOAD_SEED_JOB']) {
+    def JENKINS_SETUP_YAML = env['JENKINS_SEED_JOB'] ?: "${env['JENKINS_HOME']}/seed_job.dsl"
+    def config = new File(JENKINS_SEED_JOB).text
+
+    def workspace = new File("${env['JENKINS_HOME']}")
+    def seedJobDsl = config.seed_jobdsl
+
+    def jobManagement = new JenkinsJobManagement(System.out, [:], workspace)
+    new DslScriptLoader(jobManagement).runScript(seedJobDsl)
+    logger.info('Created seed job')
+}
+

--- a/config/s2i/jenkins/master/configuration/init.groovy
+++ b/config/s2i/jenkins/master/configuration/init.groovy
@@ -13,6 +13,9 @@ import jenkins.security.s2m.*
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
+import javaposse.jobdsl.dsl.DslScriptLoader
+import javaposse.jobdsl.plugin.JenkinsJobManagement
+
 
 import java.util.logging.Logger
 

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -11,7 +11,6 @@ job("seed") {
         dsl {
             external('src/jobs/*.groovy')
             removeAction('DISABLE')
-            ignoreExisting('false')
             additionalClasspath('lib')
         }
     }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,7 +1,7 @@
 job("seed") {
   scm {
       git(
-      ${DSL_JOB_REPO},
+      "${DSL_JOB_REPO}",
       'jobDsl',
       {node -> node / 'extensions' << '' })
   }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,4 +1,4 @@
-dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
+dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project2.git'
 
 job("seed") {
   scm {

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -7,7 +7,10 @@ job("seed") {
         'jobDsl',
         {node -> node / 'extensions' << '' })
     }
-      steps {
+    triggers {
+        githubPush()
+    }
+    steps {
         dsl {
             external('src/jobs/*.groovy')
             removeAction('DISABLE')

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,4 +1,4 @@
-dslVar = System.getenv(env.DSL_JOB_REPO) ?: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
+dslVar = System.getenv('DSL_JOB_REPO') ?: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
 
 job("seed") {
   scm {

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -15,7 +15,13 @@ job("seed") {
           external('src/jobs/*.groovy')
           removeAction('DELETE')
           additionalClasspath('src')
-          sandbox(true)
+          configure { node ->
+              node / builders  {
+                  'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
+                      sandbox('true')
+                  }
+              }
+          }
       }   
   }
 }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,0 +1,20 @@
+job("seed") {
+  scm {
+      git(
+      ${DSL_JOB_REPO}
+      'jobDsl',
+      {node -> node / 'extensions' << '' })
+  }
+  triggers {
+    githubPush()
+  }
+  steps {
+      dsl {
+          external('jobs/*.groovy')
+          removeAction('DELETE')
+          additionalClasspath('src')
+      }   
+  }
+}
+queue("seed")
+

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,4 +1,4 @@
-dslVar = System.getenv('DSL_JOB_REPO') ?: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
+dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
 
 job("seed") {
   scm {

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -12,7 +12,7 @@ job("seed") {
   }
   steps {
       dsl {
-          external('jobs/*.groovy')
+          external('src/jobs/*.groovy')
           removeAction('DELETE')
           additionalClasspath('src')
       }   

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -15,6 +15,7 @@ job("seed") {
           external('src/jobs/*.groovy')
           removeAction('DELETE')
           additionalClasspath('src')
+          sandbox()
       }   
   }
 }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,4 +1,4 @@
-dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project2.git'
+dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project.git'
 
 job("seed") {
     scm {

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,7 +1,9 @@
+dslVar = System.getenv(env.DSL_JOB_REPO) ?: 'git@github.com:CentOS-PaaS-SIG/contra-env-sample-project.git'
+
 job("seed") {
   scm {
       git(
-      "${DSL_JOB_REPO}",
+      dslVar,
       'jobDsl',
       {node -> node / 'extensions' << '' })
   }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -15,7 +15,7 @@ job("seed") {
           external('src/jobs/*.groovy')
           removeAction('DELETE')
           additionalClasspath('src')
-          sandbox()
+          sandbox(true)
       }   
   }
 }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,29 +1,29 @@
 dslVar = System.getenv('DSL_JOB_REPO') ?: 'https://github.com/CentOS-PaaS-SIG/contra-env-sample-project2.git'
 
 job("seed") {
-  scm {
-      git(
-      dslVar,
-      'jobDsl',
-      {node -> node / 'extensions' << '' })
-  }
-  triggers {
-    githubPush()
-  }
-  steps {
-      dsl {
-          external('src/jobs/*.groovy')
-          removeAction('DELETE')
-          additionalClasspath('src')
-          configure { node ->
-              node / builders  {
-                  'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
-                      sandbox('true')
-                  }
-              }
-          }
-      }   
-  }
+    scm {
+        git(
+        dslVar,
+        'jobDsl',
+        {node -> node / 'extensions' << '' })
+    }
+    triggers {
+        githubPush()
+    }
+    steps {
+        dsl {
+            external('src/jobs/*.groovy')
+            removeAction('DELETE')
+            additionalClasspath('src')
+        }   
+    }
+    configure { node ->
+        node / builders  {
+            'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
+                sandbox('true')
+            }
+        }
+    }
 }
 queue("seed")
 

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -13,8 +13,12 @@ job("seed") {
     configure {
         it / builders << 'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
                 sandbox('true')
-                external('src/jobs/*.groovy')
-                removeAction('DELETE')
+                target('src/jobs/*.groovy')
+                ignoreExisting('true')
+                removedJobAction('DELETE')
+                removedViewAction('DELETE')
+                removedConfigFilesAction('DELETE')
+                lookupStrategy('JENKINS_ROOT')
                 additionalClasspath('src')
         }
     }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -11,15 +11,13 @@ job("seed") {
         githubPush()
     }
     steps {
-        dsl {
-            external('src/jobs/*.groovy')
-            removeAction('DELETE')
-            additionalClasspath('src')
-        }   
         configure { node ->
             node / builders  {
                 'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
                     sandbox('true')
+                    external('src/jobs/*.groovy')
+                    removeAction('DELETE')
+                    additionalClasspath('src')
                 }
             }
         }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -1,7 +1,7 @@
 job("seed") {
   scm {
       git(
-      ${DSL_JOB_REPO}
+      ${DSL_JOB_REPO},
       'jobDsl',
       {node -> node / 'extensions' << '' })
   }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -7,14 +7,12 @@ job("seed") {
         'jobDsl',
         {node -> node / 'extensions' << '' })
     }
-    triggers {
-        githubPush()
-    }
     configure {
-        it / builders << 'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
+        it / builders << 'javaposse.jobdsl.plugin.ExecuteDslScripts' {
+                targets('src/jobs/*.groovy')
                 sandbox('true')
-                target('src/jobs/*.groovy')
-                ignoreExisting('true')
+                usingScriptText('false')
+                ignoreExisting('false')
                 removedJobAction('DELETE')
                 removedViewAction('DELETE')
                 removedConfigFilesAction('DELETE')

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -16,11 +16,11 @@ job("seed") {
             removeAction('DELETE')
             additionalClasspath('src')
         }   
-    }
-    configure { node ->
-        node / builders  {
-            'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
-                sandbox('true')
+        configure { node ->
+            node / builders  {
+                'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
+                    sandbox('true')
+                }
             }
         }
     }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -10,16 +10,12 @@ job("seed") {
     triggers {
         githubPush()
     }
-    steps {
-        configure { node ->
-            node / builders  {
-                'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
-                    sandbox('true')
-                    external('src/jobs/*.groovy')
-                    removeAction('DELETE')
-                    additionalClasspath('src')
-                }
-            }
+    configure {
+        it / builders << 'javaposse.jobdsl.plugin.ExecuteDslScripts'(plugin: "job-dsl@1.70") {
+                sandbox('true')
+                external('src/jobs/*.groovy')
+                removeAction('DELETE')
+                additionalClasspath('src')
         }
     }
 }

--- a/config/s2i/jenkins/master/configuration/seed_job.dsl
+++ b/config/s2i/jenkins/master/configuration/seed_job.dsl
@@ -7,17 +7,12 @@ job("seed") {
         'jobDsl',
         {node -> node / 'extensions' << '' })
     }
-    configure {
-        it / builders << 'javaposse.jobdsl.plugin.ExecuteDslScripts' {
-                targets('src/jobs/*.groovy')
-                sandbox('true')
-                usingScriptText('false')
-                ignoreExisting('false')
-                removedJobAction('DELETE')
-                removedViewAction('DELETE')
-                removedConfigFilesAction('DELETE')
-                lookupStrategy('JENKINS_ROOT')
-                additionalClasspath('src')
+      steps {
+        dsl {
+            external('src/jobs/*.groovy')
+            removeAction('DISABLE')
+            ignoreExisting('false')
+            additionalClasspath('lib')
         }
     }
 }

--- a/config/s2i/jenkins/master/plugins.txt
+++ b/config/s2i/jenkins/master/plugins.txt
@@ -46,6 +46,7 @@ github:1.29.2
 github-api:1.92
 github-branch-source:2.3.6
 github-organization-folder:1.6
+github-pr-comment-build:2.0
 gitlab-plugin:1.5.9
 git-server:1.7
 greenballs:1.15

--- a/src/jobs/multiBranchJob.groovy
+++ b/src/jobs/multiBranchJob.groovy
@@ -1,0 +1,10 @@
+multibranchPipelineJob('testPipeline') {
+    branchSources {
+        github {
+            scanCredentialsId('joejstuart - github')
+            repoOwner('joejstuart')
+            repository('cloud-image-builder')
+        }
+    }
+}
+

--- a/src/jobs/multiBranchJob.groovy
+++ b/src/jobs/multiBranchJob.groovy
@@ -2,7 +2,7 @@ multibranchPipelineJob('testPipeline') {
     branchSources {
         github {
             scanCredentialsId('contra-sample-project-github')
-            repoOwner('joejstuart')
+            repoOwner('CentOS-PaaS-SIG')
             repository('cloud-image-builder')
         }
     }

--- a/src/jobs/multiBranchJob.groovy
+++ b/src/jobs/multiBranchJob.groovy
@@ -1,9 +1,8 @@
-multibranchPipelineJob('testPipeline') {
+multibranchPipelineJob('sampleMultiBranchPipeline') {
     branchSources {
         github {
-            scanCredentialsId('contra-sample-project-github')
             repoOwner('CentOS-PaaS-SIG')
-            repository('cloud-image-builder')
+            repository('contra-env-sample-project')
         }
     }
 }

--- a/src/jobs/multiBranchJob.groovy
+++ b/src/jobs/multiBranchJob.groovy
@@ -1,7 +1,7 @@
 multibranchPipelineJob('testPipeline') {
     branchSources {
         github {
-            scanCredentialsId('joejstuart - github')
+            scanCredentialsId('contra-sample-project-github')
             repoOwner('joejstuart')
             repository('cloud-image-builder')
         }


### PR DESCRIPTION
- Adds the option to load a seed job in jenkins-persistent-template.yml
- Adds options to load dsl jobs from a repo in jenkins-persistent-template.yml
- Modifies init.groovy to load a seed job
- Default seed job is located in config/s2i/jenkins/master/configuration/seed_job.dsl (can be overridden)
- Sample dsl job located in src/jobs
- Add github-pr-comments plugin
- Load contra-lib from init.groovy as a shared library